### PR TITLE
Avoid redundant fs.writeFile() operations on same file

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -171,10 +171,38 @@ FileCookieStore.prototype.isEmpty = function (){
     return isEmptyObject(this.idx);
 }
 
-function saveToFile(filePath, data, cb) {
+// Avoid parallel writes to the same file
+var _writing_ = {};
+function writeFile(filePath, data, done) {
     var dataJson = JSON.stringify(data);
-    fs.writeFileSync(filePath, dataJson);
-    cb();
+    var wo = { done: done, next: [] };
+    _writing_[filePath] = wo;
+    fs.writeFile(filePath, dataJson, function (err) {
+        // If we have new pending writes, execute them now
+        if ( wo.next.length ) {
+            writeFile(filePath, wo.data, wo.next);
+        }
+        else {
+            delete _writing_[filePath];
+        }
+        if (err) throw err;
+        wo.done.forEach(function(cb) {
+            cb();
+        });
+    });
+}
+
+function saveToFile(filePath, data, cb) {
+    var wo = _writing_[filePath];
+    // If not writing to this file, start writing right now
+    if ( !wo ) {
+        writeFile(filePath, data, [cb]);
+    }
+    // If writing in process, add to pending
+    else {
+        wo.data = data;
+        wo.next.push(cb);
+    }
 }
 
 function loadFromFile(filePath, cb) {


### PR DESCRIPTION
Avoid redundant fs.writeFile() operations on same file.

This is the same PR as in [mitsuru/tough-cookie-filestore/#18](https://github.com/mitsuru/tough-cookie-filestore/pull/18)!