### PR TITLE
Change writeFile to writeFileSync due to race conditions

### DIFF
--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -12,9 +12,8 @@ function FileCookieStore(filePath) {
     this.filePath = filePath;
     var self = this;
     loadFromFile(this.filePath, function(dataJson) {
-        if (dataJson)
-            self.idx = dataJson;
-    })
+        if (dataJson) self.idx = dataJson;
+    });
 }
 
 util.inherits(FileCookieStore, Store);
@@ -24,7 +23,7 @@ FileCookieStore.prototype.synchronous = true;
 
 // force a default depth:
 FileCookieStore.prototype.inspect = function() {
-    return "{ idx: " + util.inspect(this.idx, false, 2) + ' }';
+    return '{ idx: ' + util.inspect(this.idx, false, 2) + ' }';
 };
 
 FileCookieStore.prototype.findCookie = function(domain, path, key, cb) {
@@ -54,7 +53,6 @@ FileCookieStore.prototype.findCookies = function(domain, path, cb) {
                 }
             }
         };
-
     } else if (path === '/') {
         pathMatcher = function matchSlash(domainIndex) {
             var pathIndex = domainIndex['/'];
@@ -65,7 +63,6 @@ FileCookieStore.prototype.findCookies = function(domain, path, cb) {
                 results.push(pathIndex[key]);
             }
         };
-
     } else {
         var paths = permutePath(path) || [path];
         pathMatcher = function matchRFC(domainIndex) {
@@ -107,15 +104,28 @@ FileCookieStore.prototype.putCookie = function(cookie, cb) {
     });
 };
 
-FileCookieStore.prototype.updateCookie = function updateCookie(oldCookie, newCookie, cb) {
+FileCookieStore.prototype.updateCookie = function updateCookie(
+    oldCookie,
+    newCookie,
+    cb
+) {
     // updateCookie() may avoid updating cookies that are identical.  For example,
     // lastAccessed may not be important to some stores and an equality
     // comparison could exclude that field.
     this.putCookie(newCookie, cb);
 };
 
-FileCookieStore.prototype.removeCookie = function removeCookie(domain, path, key, cb) {
-    if (this.idx[domain] && this.idx[domain][path] && this.idx[domain][path][key]) {
+FileCookieStore.prototype.removeCookie = function removeCookie(
+    domain,
+    path,
+    key,
+    cb
+) {
+    if (
+        this.idx[domain] &&
+        this.idx[domain][path] &&
+        this.idx[domain][path][key]
+    ) {
         delete this.idx[domain][path][key];
     }
     saveToFile(this.filePath, this.idx, function() {
@@ -123,7 +133,11 @@ FileCookieStore.prototype.removeCookie = function removeCookie(domain, path, key
     });
 };
 
-FileCookieStore.prototype.removeCookies = function removeCookies(domain, path, cb) {
+FileCookieStore.prototype.removeCookies = function removeCookies(
+    domain,
+    path,
+    cb
+) {
     if (this.idx[domain]) {
         if (path) {
             delete this.idx[domain][path];
@@ -137,98 +151,74 @@ FileCookieStore.prototype.removeCookies = function removeCookies(domain, path, c
 };
 
 FileCookieStore.prototype.checkExpired = function(domain, path, key) {
-    var domains = []
-    if (domain) domains = [domain]
-    else domains = Object.keys(this.idx)
-    var isExpired = false
-    var that = this
+    var domains = [];
+    if (domain) domains = [domain];
+    else domains = Object.keys(this.idx);
+    var isExpired = false;
+    var that = this;
     domains.forEach(function(d) {
-        var paths = []
-        if (path) paths = [path]
-        else paths = Object.keys(that.idx[d])
+        var paths = [];
+        if (path) paths = [path];
+        else paths = Object.keys(that.idx[d]);
         paths.forEach(function(p) {
-            var keys = []
-            if (key) keys = [key]
-            else keys = Object.keys(that.idx[d][p])
+            var keys = [];
+            if (key) keys = [key];
+            else keys = Object.keys(that.idx[d][p]);
             keys.forEach(function(k) {
-                var expiresDate = that.idx[d][p][k].expires
-                var now = new Date()
+                var expiresDate = that.idx[d][p][k].expires;
+                var now = new Date();
                 if (isFinite(expiresDate)) {
-                    if (expiresDate - now < 30 * 60)
-                        isExpired = true
+                    if (expiresDate - now < 30 * 60) isExpired = true;
                 }
-            })
-        })
-    })
-    return isExpired
-}
-
-FileCookieStore.prototype.isExpired = function() {
-    return this.checkExpired(null, null, null)
-}
-
-FileCookieStore.prototype.isEmpty = function (){
-    return isEmptyObject(this.idx);
-}
-
-FileCookieStore.prototype.getAllCookies = function(cb) {
-  var cookies = [];
-  var idx = this.idx;
- 
-  var domains = Object.keys(idx);
-  domains.forEach(function(domain) {
-    var paths = Object.keys(idx[domain]);
-    paths.forEach(function(path) {
-      var keys = Object.keys(idx[domain][path]);
-      keys.forEach(function(key) {
-        if (key !== null) {
-          cookies.push(idx[domain][path][key]);
-        }
-      });
-    });
-  });
- 
-  // Sort by creationIndex so deserializing retains the creation order.
-  // When implementing your own store, this SHOULD retain the order too
-  cookies.sort(function(a,b) {
-    return (a.creationIndex||0) - (b.creationIndex||0);
-  });
- 
-  cb(null, cookies);
-};
-
-// Avoid parallel writes to the same file
-var _writing_ = {};
-function writeFile(filePath, data, done) {
-    var dataJson = JSON.stringify(data);
-    var wo = { done: done, next: [] };
-    _writing_[filePath] = wo;
-    fs.writeFile(filePath, dataJson, function (err) {
-        // If we have new pending writes, execute them now
-        if ( wo.next.length ) {
-            writeFile(filePath, wo.data, wo.next);
-        }
-        else {
-            delete _writing_[filePath];
-        }
-        if (err) throw err;
-        wo.done.forEach(function(cb) {
-            cb();
+            });
         });
     });
+    return isExpired;
+};
+
+FileCookieStore.prototype.isExpired = function() {
+    return this.checkExpired(null, null, null);
+};
+
+FileCookieStore.prototype.isEmpty = function() {
+    return isEmptyObject(this.idx);
+};
+
+FileCookieStore.prototype.getAllCookies = function(cb) {
+    var cookies = [];
+    var idx = this.idx;
+
+    var domains = Object.keys(idx);
+    domains.forEach(function(domain) {
+        var paths = Object.keys(idx[domain]);
+        paths.forEach(function(path) {
+            var keys = Object.keys(idx[domain][path]);
+            keys.forEach(function(key) {
+                if (key !== null) {
+                    cookies.push(idx[domain][path][key]);
+                }
+            });
+        });
+    });
+
+    // Sort by creationIndex so deserializing retains the creation order.
+    // When implementing your own store, this SHOULD retain the order too
+    cookies.sort(function(a, b) {
+        return (a.creationIndex || 0) - (b.creationIndex || 0);
+    });
+
+    cb(null, cookies);
+};
+
+// Avoid parallel writes to the same file by using sync writes
+function writeFile(filePath, data, cb) {
+    var dataJson = JSON.stringify(data);
+    fs.writeFileSync(filePath, dataJson);
+    cb();
 }
 
 function saveToFile(filePath, data, cb) {
-    var wo = _writing_[filePath];
-    // If not writing to this file, start writing right now
-    if ( !wo ) {
-        writeFile(filePath, data, [cb]);
-    }
-    // If writing in process, add to pending
-    else {
-        wo.data = data;
-        wo.next.push(cb);
-    }
+    writeFile(filePath, data, cb);
 }
 
 function loadFromFile(filePath, cb) {
@@ -242,7 +232,11 @@ function loadFromFile(filePath, cb) {
         try {
             var dataJson = JSON.parse(data);
         } catch (e) {
-            throw new Error('Could not parse cookie file ' + filePath + '. Please ensure it is not corrupted.');
+            throw new Error(
+                'Could not parse cookie file ' +
+                    filePath +
+                    '. Please ensure it is not corrupted.'
+            );
         }
     } else {
         var dataJson = null;
@@ -251,7 +245,9 @@ function loadFromFile(filePath, cb) {
     for (var domainName in dataJson) {
         for (var pathName in dataJson[domainName]) {
             for (var cookieName in dataJson[domainName][pathName]) {
-                dataJson[domainName][pathName][cookieName] = tough.fromJSON(JSON.stringify(dataJson[domainName][pathName][cookieName]));
+                dataJson[domainName][pathName][cookieName] = tough.fromJSON(
+                    JSON.stringify(dataJson[domainName][pathName][cookieName])
+                );
             }
         }
     }

--- a/lib/file-store.js
+++ b/lib/file-store.js
@@ -12,8 +12,9 @@ function FileCookieStore(filePath) {
     this.filePath = filePath;
     var self = this;
     loadFromFile(this.filePath, function(dataJson) {
-        if (dataJson) self.idx = dataJson;
-    });
+        if (dataJson)
+            self.idx = dataJson;
+    })
 }
 
 util.inherits(FileCookieStore, Store);
@@ -23,7 +24,7 @@ FileCookieStore.prototype.synchronous = true;
 
 // force a default depth:
 FileCookieStore.prototype.inspect = function() {
-    return '{ idx: ' + util.inspect(this.idx, false, 2) + ' }';
+    return "{ idx: " + util.inspect(this.idx, false, 2) + ' }';
 };
 
 FileCookieStore.prototype.findCookie = function(domain, path, key, cb) {
@@ -53,6 +54,7 @@ FileCookieStore.prototype.findCookies = function(domain, path, cb) {
                 }
             }
         };
+
     } else if (path === '/') {
         pathMatcher = function matchSlash(domainIndex) {
             var pathIndex = domainIndex['/'];
@@ -63,6 +65,7 @@ FileCookieStore.prototype.findCookies = function(domain, path, cb) {
                 results.push(pathIndex[key]);
             }
         };
+
     } else {
         var paths = permutePath(path) || [path];
         pathMatcher = function matchRFC(domainIndex) {
@@ -104,28 +107,15 @@ FileCookieStore.prototype.putCookie = function(cookie, cb) {
     });
 };
 
-FileCookieStore.prototype.updateCookie = function updateCookie(
-    oldCookie,
-    newCookie,
-    cb
-) {
+FileCookieStore.prototype.updateCookie = function updateCookie(oldCookie, newCookie, cb) {
     // updateCookie() may avoid updating cookies that are identical.  For example,
     // lastAccessed may not be important to some stores and an equality
     // comparison could exclude that field.
     this.putCookie(newCookie, cb);
 };
 
-FileCookieStore.prototype.removeCookie = function removeCookie(
-    domain,
-    path,
-    key,
-    cb
-) {
-    if (
-        this.idx[domain] &&
-        this.idx[domain][path] &&
-        this.idx[domain][path][key]
-    ) {
+FileCookieStore.prototype.removeCookie = function removeCookie(domain, path, key, cb) {
+    if (this.idx[domain] && this.idx[domain][path] && this.idx[domain][path][key]) {
         delete this.idx[domain][path][key];
     }
     saveToFile(this.filePath, this.idx, function() {
@@ -133,11 +123,7 @@ FileCookieStore.prototype.removeCookie = function removeCookie(
     });
 };
 
-FileCookieStore.prototype.removeCookies = function removeCookies(
-    domain,
-    path,
-    cb
-) {
+FileCookieStore.prototype.removeCookies = function removeCookies(domain, path, cb) {
     if (this.idx[domain]) {
         if (path) {
             delete this.idx[domain][path];
@@ -151,66 +137,67 @@ FileCookieStore.prototype.removeCookies = function removeCookies(
 };
 
 FileCookieStore.prototype.checkExpired = function(domain, path, key) {
-    var domains = [];
-    if (domain) domains = [domain];
-    else domains = Object.keys(this.idx);
-    var isExpired = false;
-    var that = this;
+    var domains = []
+    if (domain) domains = [domain]
+    else domains = Object.keys(this.idx)
+    var isExpired = false
+    var that = this
     domains.forEach(function(d) {
-        var paths = [];
-        if (path) paths = [path];
-        else paths = Object.keys(that.idx[d]);
+        var paths = []
+        if (path) paths = [path]
+        else paths = Object.keys(that.idx[d])
         paths.forEach(function(p) {
-            var keys = [];
-            if (key) keys = [key];
-            else keys = Object.keys(that.idx[d][p]);
+            var keys = []
+            if (key) keys = [key]
+            else keys = Object.keys(that.idx[d][p])
             keys.forEach(function(k) {
-                var expiresDate = that.idx[d][p][k].expires;
-                var now = new Date();
+                var expiresDate = that.idx[d][p][k].expires
+                var now = new Date()
                 if (isFinite(expiresDate)) {
-                    if (expiresDate - now < 30 * 60) isExpired = true;
+                    if (expiresDate - now < 30 * 60)
+                        isExpired = true
                 }
-            });
-        });
-    });
-    return isExpired;
-};
+            })
+        })
+    })
+    return isExpired
+}
 
 FileCookieStore.prototype.isExpired = function() {
-    return this.checkExpired(null, null, null);
-};
+    return this.checkExpired(null, null, null)
+}
 
-FileCookieStore.prototype.isEmpty = function() {
+FileCookieStore.prototype.isEmpty = function (){
     return isEmptyObject(this.idx);
-};
+}
 
 FileCookieStore.prototype.getAllCookies = function(cb) {
-    var cookies = [];
-    var idx = this.idx;
-
-    var domains = Object.keys(idx);
-    domains.forEach(function(domain) {
-        var paths = Object.keys(idx[domain]);
-        paths.forEach(function(path) {
-            var keys = Object.keys(idx[domain][path]);
-            keys.forEach(function(key) {
-                if (key !== null) {
-                    cookies.push(idx[domain][path][key]);
-                }
-            });
-        });
+  var cookies = [];
+  var idx = this.idx;
+ 
+  var domains = Object.keys(idx);
+  domains.forEach(function(domain) {
+    var paths = Object.keys(idx[domain]);
+    paths.forEach(function(path) {
+      var keys = Object.keys(idx[domain][path]);
+      keys.forEach(function(key) {
+        if (key !== null) {
+          cookies.push(idx[domain][path][key]);
+        }
+      });
     });
-
-    // Sort by creationIndex so deserializing retains the creation order.
-    // When implementing your own store, this SHOULD retain the order too
-    cookies.sort(function(a, b) {
-        return (a.creationIndex || 0) - (b.creationIndex || 0);
-    });
-
-    cb(null, cookies);
+  });
+ 
+  // Sort by creationIndex so deserializing retains the creation order.
+  // When implementing your own store, this SHOULD retain the order too
+  cookies.sort(function(a,b) {
+    return (a.creationIndex||0) - (b.creationIndex||0);
+  });
+ 
+  cb(null, cookies);
 };
 
-// Avoid parallel writes to the same file by using sync writes
+// Avoid parallel writes to the same file by writing synchronously
 function writeFile(filePath, data, cb) {
     var dataJson = JSON.stringify(data);
     fs.writeFileSync(filePath, dataJson);
@@ -232,11 +219,7 @@ function loadFromFile(filePath, cb) {
         try {
             var dataJson = JSON.parse(data);
         } catch (e) {
-            throw new Error(
-                'Could not parse cookie file ' +
-                    filePath +
-                    '. Please ensure it is not corrupted.'
-            );
+            throw new Error('Could not parse cookie file ' + filePath + '. Please ensure it is not corrupted.');
         }
     } else {
         var dataJson = null;
@@ -245,9 +228,7 @@ function loadFromFile(filePath, cb) {
     for (var domainName in dataJson) {
         for (var pathName in dataJson[domainName]) {
             for (var cookieName in dataJson[domainName][pathName]) {
-                dataJson[domainName][pathName][cookieName] = tough.fromJSON(
-                    JSON.stringify(dataJson[domainName][pathName][cookieName])
-                );
+                dataJson[domainName][pathName][cookieName] = tough.fromJSON(JSON.stringify(dataJson[domainName][pathName][cookieName]));
             }
         }
     }


### PR DESCRIPTION
When using/authenticating with https://github.com/passbolt/passbolt_cli , the cookie file is written and then immediately wiped before the process ends.  By changing async file writes to sync file writes, the passbolt cookie file is written properly.

I suspect this is related to a change in https://github.com/salesforce/tough-cookie made sometime in the last 2 years.