### PR TITLE
fix: missed inspect rename from b27a42bc

### DIFF
--- a/lib/cookie-file-store.js
+++ b/lib/cookie-file-store.js
@@ -21,7 +21,7 @@ class FileCookieStore extends Store {
     this.filePath = filePath
     /* istanbul ignore else  */
     if (util.inspect.custom) {
-      this[util.inspect.custom] = this.inspect
+      this[util.inspect.custom] = this._inspect
     }
     const self = this
     /* istanbul ignore else  */


### PR DESCRIPTION
I noticed this when i was reviewing what changed in this library while reviewing https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44753