### PR TITLE
fix: use explicit extension to address Node error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tough-cookie": "^5.0.0"
   },
   "type": "module",
-  "main": "lib/cookie-file-store",
+  "main": "lib/cookie-file-store.js",
   "engines": {
     "node": ">=16"
   },


### PR DESCRIPTION
Currently, loading this package shows this error:

> (node:87036) [DEP0151] DeprecationWarning: Package /node_modules/tough-cookie-file-store/ has a "main" field set to "lib/cookie-file-store", excluding the full filename and extension to the resolved file at "lib/cookie-file-store.js", imported from script.ts.
 Automatic extension resolution of the "main" field is deprecated for ES modules.