### PR TITLE
fix vscode unable to find files from tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,13 +33,6 @@
   "engines": {
     "node": ">=16"
   },
-  "files": [
-    "dist/**/*.js",
-    "dist/**/*.js.map",
-    "dist/**/*.d.ts",
-    "dist/**/*.ts.map",
-    "CHANGELOG.md"
-  ],
   "scripts": {
     "lint": "eslint lib test --color",
     "lint:fix": "eslint lib test --fix",


### PR DESCRIPTION
This fixes an error in vscode where it couldn't find the ts files from tsconfig.json

<img width="1135" alt="Screenshot 2025-07-03 at 6 00 46 PM" src="https://github.com/user-attachments/assets/37661465-e7ae-41cb-b559-bc0f661f24fd" />
